### PR TITLE
Tweak CSS

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -159,3 +159,7 @@ abbr[epub|type~="se:era"]{
 #memoir-2 time{
 	font-style: italic;
 }
+
+#memoir-2 [epub|type~="z3998:letter"] header time{
+	font-style: normal;
+}


### PR DESCRIPTION
I forgot that there was a `<time>` in the Second Memoir letter header, which shouldn't be italicized: https://archive.org/details/what-is-property/page/290/mode/2up